### PR TITLE
Make `loaders` a list in configuration docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,11 +111,13 @@ instead. ::
         {
             'BACKEND': 'django.template.backends.django.DjangoTemplates',
             'OPTIONS': {
-                'loaders': ('app_namespace.Loader',
-                           'django.template.loaders.filesystem.Loader',
-                           'django.template.loaders.app_directories.Loader')
-            }
-        }
+                'loaders': [
+                    'app_namespace.Loader',
+                    'django.template.loaders.filesystem.Loader',
+                    'django.template.loaders.app_directories.Loader',
+                ],
+            },
+        },
     ]
 
 Known limitations


### PR DESCRIPTION
This is to match the Django `TEMPLATES` configuration more closely (e.g. [Upgrading templates to Django 1.8](https://docs.djangoproject.com/en/1.8/ref/templates/upgrading/#the-templates-settings)). The settings for template loaders is a list in Django 1.8.